### PR TITLE
Add docker-compose to docker-ce image

### DIFF
--- a/apps/hetzner/docker-ce/scripts/docker.sh
+++ b/apps/hetzner/docker-ce/scripts/docker.sh
@@ -15,7 +15,7 @@ Pin-Priority: 500
 EOT
 
 apt-get -y update
-apt-get -y install docker-ce docker-compose
+apt-get -y install docker-ce docker-compose-plugin
 
 systemctl enable docker
 systemctl start docker

--- a/apps/hetzner/docker-ce/scripts/docker.sh
+++ b/apps/hetzner/docker-ce/scripts/docker.sh
@@ -15,7 +15,7 @@ Pin-Priority: 500
 EOT
 
 apt-get -y update
-apt-get -y install docker-ce
+apt-get -y install docker-ce docker-compose
 
 systemctl enable docker
 systemctl start docker


### PR DESCRIPTION
The docker-ce image was missing `docker-compose` which is added here.