### PR TITLE
[DockerCE] Use Ubuntu 22.04 as base image

### DIFF
--- a/apps/hetzner/docker-ce/README.de.md
+++ b/apps/hetzner/docker-ce/README.de.md
@@ -43,13 +43,14 @@ Anstelle der Hetzner Cloud Console kann zum Einrichten eines Servers mit vorinst
 
 ### Betriebssystem
 
-- [x] Ubuntu 20.04
+- [x] Ubuntu 22.04
 
 ### Installierte Pakete
 
-| NAME   | LIZENZ             |
-| ------ | ------------------ |
-| Docker | GPLv3 (Apache 2.0) |
+| NAME                  | LIZENZ             |
+| --------------------- | ------------------ |
+| Docker                | GPLv3 (Apache 2.0) |
+| Docker Compose Plugin |                    |
 
 ## Links
 

--- a/apps/hetzner/docker-ce/README.md
+++ b/apps/hetzner/docker-ce/README.md
@@ -43,13 +43,14 @@ In addition to the Hetzner Cloud Console you can also use the Hetzner Cloud API 
 
 ### Base OS
 
-- [x] Ubuntu 20.04
+- [x] Ubuntu 22.04
 
 ### Installed packages
 
-| NAME   | LICENSE            |
-| ------ | ------------------ |
-| Docker | GPLv3 (Apache 2.0) |
+| NAME                  | LICENSE            |
+| --------------------- | ------------------ |
+| Docker                | GPLv3 (Apache 2.0) |
+| Docker Compose Plugin |                    |
 
 ## Links
 

--- a/apps/hetzner/docker-ce/metadata.json
+++ b/apps/hetzner/docker-ce/metadata.json
@@ -3,7 +3,7 @@
   "description_en": "Docker is an open source project that automates the deployment of code inside software containers. It uses OS-level virtualization to deliver software in packages called containers.",
   "documentation_url": "https://docs.hetzner.com/cloud/apps/list/docker-ce",
   "name": "Docker CE",
-  "os_id": 15512617,
+  "os_id": 67794396,
   "packages": [
     {
       "license": "GPLv3 (Apache-2.0)",

--- a/apps/hetzner/docker-ce/template.pkr.hcl
+++ b/apps/hetzner/docker-ce/template.pkr.hcl
@@ -11,7 +11,7 @@ variable "app_version" {
 
 variable "hcloud_image" {
   type    = string
-  default = "ubuntu-20.04"
+  default = "ubuntu-22.04"
 }
 
 variable "git-sha" {


### PR DESCRIPTION
This resolves https://github.com/hetznercloud/apps/issues/61

Signed-off-by: Robert Müller 🚀 <robert.mueller@hetzner-cloud.de>