### PR TITLE
[WireGuard] Update wireguard-ui fork

### DIFF
--- a/apps/hetzner/wireguard/template.pkr.hcl
+++ b/apps/hetzner/wireguard/template.pkr.hcl
@@ -21,7 +21,7 @@ variable "apt_packages" {
 
 variable "wireguard_ui_version" {
   type    = string
-  default = "0.4.2"
+  default = "0.4.3"
 }
 
 variable "caddy_version" {


### PR DESCRIPTION
This applies a patch to fix an error on IPv6-only servers: https://github.com/ngoduykhanh/wireguard-ui/pull/240