### PR TITLE
Packer: allow different server types on build

### DIFF
--- a/apps/hetzner/collab-tools/template.pkr.hcl
+++ b/apps/hetzner/collab-tools/template.pkr.hcl
@@ -8,6 +8,11 @@ variable "app_version" {
   default = "latest"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cpx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/docker-ce/template.pkr.hcl
+++ b/apps/hetzner/docker-ce/template.pkr.hcl
@@ -8,6 +8,11 @@ variable "app_version" {
   default = "latest"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cpx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/gitlab/template.pkr.hcl
+++ b/apps/hetzner/gitlab/template.pkr.hcl
@@ -8,6 +8,11 @@ variable "app_version" {
   default = "15.6"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cpx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/go/template.pkr.hcl
+++ b/apps/hetzner/go/template.pkr.hcl
@@ -13,6 +13,11 @@ variable "app_checksum" {
   default = "000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cpx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/jitsi/template.pkr.hcl
+++ b/apps/hetzner/jitsi/template.pkr.hcl
@@ -8,6 +8,11 @@ variable "app_version" {
   default = "2"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cpx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-20.04"

--- a/apps/hetzner/lamp/template.pkr.hcl
+++ b/apps/hetzner/lamp/template.pkr.hcl
@@ -8,6 +8,11 @@ variable "app_version" {
   default = "latest"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cpx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/nextcloud/template.pkr.hcl
+++ b/apps/hetzner/nextcloud/template.pkr.hcl
@@ -13,6 +13,11 @@ variable "app_checksum" {
   default = "448c6b67dd754ce375c9692decb6ed6eab22f15ee9da2d3efca949ddce7fd23f"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cpx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/prometheus-grafana/template.pkr.hcl
+++ b/apps/hetzner/prometheus-grafana/template.pkr.hcl
@@ -8,6 +8,11 @@ variable "app_version" {
   default = "latest"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cpx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/ruby/template.pkr.hcl
+++ b/apps/hetzner/ruby/template.pkr.hcl
@@ -8,6 +8,11 @@ variable "app_version" {
   default = "3"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cpx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/wireguard/template.pkr.hcl
+++ b/apps/hetzner/wireguard/template.pkr.hcl
@@ -8,6 +8,11 @@ variable "app_version" {
   default = "latest"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/wordpress/template.pkr.hcl
+++ b/apps/hetzner/wordpress/template.pkr.hcl
@@ -13,6 +13,11 @@ variable "app_checksum" {
   default = "80f0f829645dec07c68bcfe0a0a1e1d563992fcb"
 }
 
+variable "hcloud_server_type" {
+  type    = string
+  default = "cx11"
+}
+
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/shared/defaults.pkr.hcl
+++ b/apps/shared/defaults.pkr.hcl
@@ -14,12 +14,6 @@ variable "hcloud_api_token" {
   sensitive = true
 }
 
-variable "hcloud_server_type" {
-  type = string
-  default = "${env("HCLOUD_SERVER_TYPE")}"
-  sensitive = true
-}
-
 variable "hcloud_server_location" {
   type = string
   default = "${env("HCLOUD_SERVER_LOCATION")}"


### PR DESCRIPTION
Depending on software requirements, we want to use different server types to build the images. Some software might run on a cx11 with 20GB hard disk, while other software might need a more powerful server with bigger hard disk.

Each image must set the Packer variable `hcloud_server_type`, which is then used by the shared template in the Packer source to start the right server.