### PR TITLE
Revert "Packer: allow different server types on build"

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -9,6 +9,8 @@ inputs:
     required: true
   server_type:
     required: true
+  base_server_type:
+    required: true
 runs:
   using: "composite"
   steps:
@@ -43,6 +45,7 @@ runs:
         target: apps/hetzner/${{ inputs.app }}/
       env:
         HCLOUD_API_TOKEN: ${{ inputs.token }}
+        HCLOUD_BASE_SERVER_TYPE: ${{ inputs.base_server_type }}
         HCLOUD_SERVER_TYPE: ${{ inputs.server_type }}
         HCLOUD_SERVER_LOCATION: ${{ inputs.server_location }}
 

--- a/.github/workflows/packer-collab-tools.yml
+++ b/.github/workflows/packer-collab-tools.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/.github/workflows/packer-docker-ce.yml
+++ b/.github/workflows/packer-docker-ce.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/.github/workflows/packer-gitlab.yml
+++ b/.github/workflows/packer-gitlab.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/.github/workflows/packer-go.yml
+++ b/.github/workflows/packer-go.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/.github/workflows/packer-jitsi.yml
+++ b/.github/workflows/packer-jitsi.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/.github/workflows/packer-lamp.yml
+++ b/.github/workflows/packer-lamp.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/.github/workflows/packer-nextcloud.yml
+++ b/.github/workflows/packer-nextcloud.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/.github/workflows/packer-prometheus-grafana.yml
+++ b/.github/workflows/packer-prometheus-grafana.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/.github/workflows/packer-ruby.yml
+++ b/.github/workflows/packer-ruby.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/.github/workflows/packer-wireguard.yml
+++ b/.github/workflows/packer-wireguard.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/.github/workflows/packer-wordpress.yml
+++ b/.github/workflows/packer-wordpress.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ github.ref == 'refs/heads/main' && secrets.HCLOUD_API_TOKEN || secrets.HCLOUD_API_TOKEN_STAGING }}
           server_location: ${{ secrets.HCLOUD_SERVER_LOCATION }}
           server_type: ${{ secrets.HCLOUD_SERVER_TYPE }}
+          base_server_type: ${{ secrets.HCLOUD_BASE_SERVER_TYPE }}

--- a/apps/hetzner/collab-tools/template.pkr.hcl
+++ b/apps/hetzner/collab-tools/template.pkr.hcl
@@ -8,11 +8,6 @@ variable "app_version" {
   default = "latest"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cpx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/docker-ce/template.pkr.hcl
+++ b/apps/hetzner/docker-ce/template.pkr.hcl
@@ -8,11 +8,6 @@ variable "app_version" {
   default = "latest"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cpx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/gitlab/metadata.json
+++ b/apps/hetzner/gitlab/metadata.json
@@ -22,6 +22,6 @@
       "name": "Postfix"
     }
   ],
-  "recommended_server_type": 5,
+  "recommended_server_type": 23,
   "version": "15.6"
 }

--- a/apps/hetzner/gitlab/template.pkr.hcl
+++ b/apps/hetzner/gitlab/template.pkr.hcl
@@ -8,11 +8,6 @@ variable "app_version" {
   default = "15.6"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cpx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/go/template.pkr.hcl
+++ b/apps/hetzner/go/template.pkr.hcl
@@ -13,11 +13,6 @@ variable "app_checksum" {
   default = "000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cpx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/jitsi/template.pkr.hcl
+++ b/apps/hetzner/jitsi/template.pkr.hcl
@@ -8,11 +8,6 @@ variable "app_version" {
   default = "2"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cpx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-20.04"

--- a/apps/hetzner/lamp/template.pkr.hcl
+++ b/apps/hetzner/lamp/template.pkr.hcl
@@ -8,11 +8,6 @@ variable "app_version" {
   default = "latest"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cpx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/nextcloud/template.pkr.hcl
+++ b/apps/hetzner/nextcloud/template.pkr.hcl
@@ -13,11 +13,6 @@ variable "app_checksum" {
   default = "448c6b67dd754ce375c9692decb6ed6eab22f15ee9da2d3efca949ddce7fd23f"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cpx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/prometheus-grafana/template.pkr.hcl
+++ b/apps/hetzner/prometheus-grafana/template.pkr.hcl
@@ -8,11 +8,6 @@ variable "app_version" {
   default = "latest"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cpx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/ruby/template.pkr.hcl
+++ b/apps/hetzner/ruby/template.pkr.hcl
@@ -8,11 +8,6 @@ variable "app_version" {
   default = "3"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cpx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/wireguard/README.md
+++ b/apps/hetzner/wireguard/README.md
@@ -41,14 +41,14 @@ Instead of the Hetzner Cloud Console, the Hetzner Cloud API can also be used to 
      -X POST \
      -H "Authorization: Bearer $API_TOKEN" \
      -H "Content-Type: application/json" \
-     -d '{"name": "my-server", "server_type": "cx11", "image": "wireguard"}' \
+     -d '{"name": "my-server", "server_type": "cpx11", "image": "wireguard"}' \
      'https://api.hetzner.cloud/v1/servers'
   ```
 
 - Or via [hcloud-cli](https://github.com/hetznercloud/cli)
 
   ```
-  hcloud server create --name my-server --type cx11 --image wireguard
+  hcloud server create --name my-server --type cpx11 --image wireguard
   ```
 
 ## Connecting VPN clients

--- a/apps/hetzner/wireguard/metadata.json
+++ b/apps/hetzner/wireguard/metadata.json
@@ -18,6 +18,6 @@
       "name": "Caddy"
     }
   ],
-  "recommended_server_type": 1,
+  "recommended_server_type": 22,
   "version": "latest"
 }

--- a/apps/hetzner/wireguard/template.pkr.hcl
+++ b/apps/hetzner/wireguard/template.pkr.hcl
@@ -8,11 +8,6 @@ variable "app_version" {
   default = "latest"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/hetzner/wordpress/template.pkr.hcl
+++ b/apps/hetzner/wordpress/template.pkr.hcl
@@ -13,11 +13,6 @@ variable "app_checksum" {
   default = "80f0f829645dec07c68bcfe0a0a1e1d563992fcb"
 }
 
-variable "hcloud_server_type" {
-  type    = string
-  default = "cx11"
-}
-
 variable "hcloud_image" {
   type    = string
   default = "ubuntu-22.04"

--- a/apps/shared/defaults.pkr.hcl
+++ b/apps/shared/defaults.pkr.hcl
@@ -14,9 +14,15 @@ variable "hcloud_api_token" {
   sensitive = true
 }
 
-variable "hcloud_server_type" {
+variable "hcloud_upgrade_server_type" {
   type = string
   default = "${env("HCLOUD_SERVER_TYPE")}"
+  sensitive = true
+}
+
+variable "hcloud_server_type" {
+  type = string
+  default = "${env("HCLOUD_BASE_SERVER_TYPE")}"
   sensitive = true
 }
 

--- a/apps/shared/defaults.pkr.hcl
+++ b/apps/shared/defaults.pkr.hcl
@@ -14,6 +14,12 @@ variable "hcloud_api_token" {
   sensitive = true
 }
 
+variable "hcloud_server_type" {
+  type = string
+  default = "${env("HCLOUD_SERVER_TYPE")}"
+  sensitive = true
+}
+
 variable "hcloud_server_location" {
   type = string
   default = "${env("HCLOUD_SERVER_LOCATION")}"


### PR DESCRIPTION
This reverts commit 7647c17ffc069c303425adb25935ab83da8c711d.

> Depending on software requirements, we want to use different server types to build the images. Some software might run on a cx11 with 20GB hard disk, while other software might need a more powerful server with bigger hard disk.

This is/was a misconception of the build process. The unified type has been introduced not that long ago for various reasons including:
- at the moment we don't need different disk-sizes but there is a plan to do it if ever necessary
- CI-variables allow to easily adjust types/locations

The hcloud-Packer plugin allows to create a VM with type X and (auto-rescale) to Type Y (without increasing the disk size, see: https://github.com/hashicorp/packer-plugin-hcloud/blob/main/docs/builders/hetzner-cloud.mdx#optional)
> Improves building performance. The resulting snapshot is compatible with smaller server types and disk sizes.

This is what we want ^^^ and which fixes the issue commit 7647c17ffc069c303425adb25935ab83da8c711d tried to fix.
