### PR TITLE
[Gitlab] bump metadata

### DIFF
--- a/apps/hetzner/gitlab/metadata.json
+++ b/apps/hetzner/gitlab/metadata.json
@@ -23,5 +23,5 @@
     }
   ],
   "recommended_server_type": 23,
-  "version": "15.6"
+  "version": "15.9"
 }


### PR DESCRIPTION
During the version bump to Gitlab 15.9 we have missed to bump the version in our metadata too.