### PR TITLE
[WireGuard] Update wireguard-ui and caddy

### DIFF
--- a/apps/hetzner/wireguard/README.de.md
+++ b/apps/hetzner/wireguard/README.de.md
@@ -87,7 +87,7 @@ Um das Admin-Passwort der Management-UI zu ändern, folgen Sie bitte diesen Schr
 1. Generieren Sie einen bcrypt Passwort-Hash für das neue Passwort. Sie können dafür die Caddy CLI benutzen:
 
    ```
-   caddy hash-password -algorithm bcrypt
+   caddy hash-password --algorithm bcrypt | tr -d '\n' | base64 -w0 && echo
    ```
 
 2. Bearbeiten Sie `/usr/local/share/wireguard-ui/db/server/users.json` und ersetzen Sie den `password_hash` mit dem soeben generierten, neuen Hash.
@@ -112,7 +112,7 @@ Für Caddy können Sie die aktuellste `caddy_*_linux_amd64.tar.gz` von der [Rele
 tar -C /usr/local/bin -xzf caddy_*_linux_amd64.tar.gz caddy
 ```
 
-Um WireGuard UI zu aktualisieren, laden Sie bitte das neueste Release-Archiv von deren [Release-Seite](https://github.com/ngoduykhanh/wireguard-ui/releases) herunter und entpacken Sie die `wireguard-ui` Binärdatei nach `/usr/local/bin`, ähnlich wie oben gezeigt. Aufgrund von jüngsten Patches, die noch nicht in den offiziellen WireGuard UI Releases angekommen sind, finden Sie [hier](https://github.com/MarcusWichelmann/wireguard-ui/releases) möglicherweise vorrübergehend aktuellere Builds. Wenn dies der Fall ist, nutzen Sie bitte diese.
+Um WireGuard UI zu aktualisieren, laden Sie bitte das neueste Release-Archiv von deren [Release-Seite](https://github.com/ngoduykhanh/wireguard-ui/releases) herunter und entpacken Sie die `wireguard-ui` Binärdatei nach `/usr/local/bin`, ähnlich wie oben gezeigt.
 
 Nachdem alles wieder auf dem neuesten Stand ist, können Sie die betroffenen Dienste neustarten:
 

--- a/apps/hetzner/wireguard/README.md
+++ b/apps/hetzner/wireguard/README.md
@@ -87,7 +87,7 @@ To change the admin password of the management UI, please follow these steps:
 1. Generate a bcrypt password hash of the new password, you can use the caddy cli for that:
 
    ```
-   caddy hash-password -algorithm bcrypt
+   caddy hash-password --algorithm bcrypt | tr -d '\n' | base64 -w0 && echo
    ```
 
 2. Edit `/usr/local/share/wireguard-ui/db/server/users.json` and replace the `password_hash` with the newly generated hash.
@@ -112,7 +112,7 @@ You can download the latest Caddy `caddy_*_linux_amd64.tar.gz` from their [relea
 tar -C /usr/local/bin -xzf caddy_*_linux_amd64.tar.gz caddy
 ```
 
-To update WireGuard UI, please download the latest release from their [releases page](https://github.com/ngoduykhanh/wireguard-ui/releases) and extract the `wireguard-ui` binary to `/usr/local/bin` like shown above. Because of some recent patches, that did not make it into the latest WireGuard UI release yet, you might temporarily find more up to date builds [here](https://github.com/MarcusWichelmann/wireguard-ui/releases). If this is the case, please use these.
+To update WireGuard UI, please download the latest release from their [releases page](https://github.com/ngoduykhanh/wireguard-ui/releases) and extract the `wireguard-ui` binary to `/usr/local/bin` like shown above.
 
 After everything is up to date again, please restart the affected systemd services:
 

--- a/apps/hetzner/wireguard/files/opt/hcloud/wireguard_setup.sh
+++ b/apps/hetzner/wireguard/files/opt/hcloud/wireguard_setup.sh
@@ -75,8 +75,8 @@ done
 
 echo "Installing. Please wait..."
 
-# Hash password
-password_hash=$(caddy hash-password -algorithm bcrypt -plaintext "$password")
+# Hash password and encode it again with base64 to be compatible with the format wireguard-ui requires
+password_hash=$(caddy hash-password --algorithm bcrypt --plaintext "$password" | tr -d '\n' | base64 -w0)
 
 # Populate the wireguard-ui default config
 sed -i "s/\$session_secret/$session_secret/g" /etc/default/wireguard-ui

--- a/apps/hetzner/wireguard/scripts/install.sh
+++ b/apps/hetzner/wireguard/scripts/install.sh
@@ -2,9 +2,7 @@
 set -e
 
 # Download the given version of wireguard-ui
-# TODO: For now, we use a fork of wireguard-ui that contains some fixes that have not been merged into upstream yet.
-# As soon as these fixes, or similar ones, are merged, we should switch back to a release by https://github.com/ngoduykhanh/wireguard-ui.
-wget "https://github.com/MarcusWichelmann/wireguard-ui/releases/download/v${wireguard_ui_version}/wireguard-ui-v${wireguard_ui_version}-linux-amd64.tar.gz" -O /tmp/wireguard-ui.tar.gz
+wget "https://github.com/ngoduykhanh/wireguard-ui/releases/download/v${wireguard_ui_version}/wireguard-ui-v${wireguard_ui_version}-linux-amd64.tar.gz" -O /tmp/wireguard-ui.tar.gz
 
 # Unpack wireguard-ui
 tar -C /usr/local/bin -xzf /tmp/wireguard-ui.tar.gz wireguard-ui

--- a/apps/hetzner/wireguard/template.pkr.hcl
+++ b/apps/hetzner/wireguard/template.pkr.hcl
@@ -20,12 +20,12 @@ variable "apt_packages" {
 
 variable "wireguard_ui_version" {
   type    = string
-  default = "0.4.3"
+  default = "0.4.0"
 }
 
 variable "caddy_version" {
   type    = string
-  default = "2.5.1"
+  default = "2.6.4"
 }
 
 build {


### PR DESCRIPTION
Because all required wireguard-ui patches were merged and released now, we can switch back to upstream instead of my fork. Also, a recent caddy release brought a breaking change in the behavior of `caddy hash-password`, so the install script and README was updated to reflect that. But there are upcoming changes in wireguard-ui, that will add an UI way to change the password. When this is released, we can remove the command from the README.

@networkpanic Maybe don't merge this until I'm back from vacation, just to be safe ;)