### PR TITLE
nextcloud-READMEs: Korrektur der verwendeten Version von Ubuntu Server

### DIFF
--- a/apps/hetzner/nextcloud/README.de.md
+++ b/apps/hetzner/nextcloud/README.de.md
@@ -66,7 +66,7 @@ Um Let's Encrypt nachträglich zu aktivieren, führen Sie bitte folgende Schritt
 
 ### Betriebssystem
 
-- [x] Ubuntu 20.04
+- [x] Ubuntu 22.04
 
 ### Installierte Pakete
 

--- a/apps/hetzner/nextcloud/README.md
+++ b/apps/hetzner/nextcloud/README.md
@@ -69,7 +69,7 @@ To activate Let's Encrypt after the initial script has run, please follow the st
 
 ### Base OS
 
-- [x] Ubuntu 20.04
+- [x] Ubuntu 22.04
 
 ### Installed packages
 


### PR DESCRIPTION
Die READMEs haben noch Version 20.04 angegeben, mittlerweile werden mit den Vorlagen Server auf Basis von Ubuntu 22.04 erstellt.