### PR TITLE
Photoprism: Fix traefik.docker.network label

### DIFF
--- a/apps/hetzner/photoprism/files/opt/containers/photoprism/docker-compose.yml
+++ b/apps/hetzner/photoprism/files/opt/containers/photoprism/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       - "photoprism_storage:/photoprism/storage" # *writable* storage folder for cache, database, and sidecar files (never remove)
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=proxy"
+      - "traefik.docker.network=photoprism_proxy"
       - "traefik.http.routers.photoprism.rule=Host(`${PHOTOPRISM_DOMAIN}`)"
       - "traefik.http.routers.photoprism.entrypoints=https"
       - "traefik.http.routers.photoprism.tls.certresolver=mytlschallenge"


### PR DESCRIPTION
Docker compose prefixes the network name with the project name, but Traefik is unaware of it. This fixes the warning from Traefik:

```
time="2023-07-09T10:47:14Z" level=debug msg="Could not find network named \"proxy\" for container \"/photoprism\". Maybe you're missing the project's prefix in the label?" container=photoprism-photoprism-659a4840e959f97a49165e164927588ac8da5e67c2d65552392925eaa4af68f4 serviceName=photoprism providerName=docker
```