### PR TITLE
fix: correct path for hedgedoc manage_users binary alias

### DIFF
--- a/apps/hetzner/collab-tools/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/apps/hetzner/collab-tools/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -11,7 +11,7 @@ EOM
 
 # Add alias to simplify managing HedgeDoc users
 cat >> /root/.bashrc <<EOM
-alias hedgedoc_users='docker compose -f /opt/containers/collab-tools/docker-compose.yml exec hedgedoc bin/manage_users'
+alias hedgedoc_users='docker compose -f /opt/containers/collab-tools/docker-compose.yml exec hedgedoc /app/hedgedoc/bin/manage_users'
 EOM
 
 # Save the passwords


### PR DESCRIPTION
bin/manage_users fails with "no such file or directory: unknown". HedgeDoc's manage_users binary is found in /app/hedgedoc/bin.