### PR TITLE
Apps: Update watchtower image for owncast app

### DIFF
--- a/apps/hetzner/owncast/files/opt/containers/owncast/docker-compose.yml
+++ b/apps/hetzner/owncast/files/opt/containers/owncast/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 
 services:
   watchtower:
-    image: containrrr/watchtower:latest
+    image: nickfedor/watchtower:latest
     container_name: "watchtower"
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Use nickfedor/watchtower:latest image

The containrrr/watchtower:latest image is outdated and breaks on apt update (see https://evilgeniusrobot.uk/posts/updating-watchtower-for-hetzner-owncast.html).